### PR TITLE
Fix for issue #1 (deprecated use of joblib)

### DIFF
--- a/pyea/models/ga.py
+++ b/pyea/models/ga.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.core.defchararray import add
 import pandas as pd
 from scipy.stats import norm
-from sklearn.externals.joblib import Parallel, delayed, cpu_count
+from joblib import Parallel, delayed, cpu_count
 import itertools
 
 # Is different in 0.15, copy version from 0.16-git


### PR DESCRIPTION
The joblib import is deprecated. This is a fix to issue #1 , which is very similar to another issue on costcla https://github.com/albahnsen/CostSensitiveClassification/issues/22